### PR TITLE
Upgrade for datasette-publish-now 0.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         NOW_TOKEN: ${{ secrets.NOW_TOKEN }}
       run: |-
-        datasette publish now2 til.db \
+        datasette publish now til.db \
           --token $NOW_TOKEN \
           --project ashish-til \
           --metadata metadata.json \


### PR DESCRIPTION
Now that the plugin is out of alpha the command has been renamed from `datasette publish now2` to just `datasette publish now`. https://github.com/simonw/datasette-publish-now/releases/tag/0.5